### PR TITLE
Change order to avoid overwriting the value

### DIFF
--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -98,9 +98,9 @@ pub fn parse_64bits_emu32(
 ) -> Option<(AddrType, String)> {
     let mut context = SpacesStruct::default();
     context.register_mut().write_longMode_raw(0).unwrap();
+    context.register_mut().write_bit64_raw(1).unwrap();
     context.register_mut().write_addrsize_raw(1).unwrap();
 
-    context.register_mut().write_bit64_raw(1).unwrap();
     context.register_mut().write_opsize_raw(1).unwrap();
     context.register_mut().write_segover_raw(0).unwrap();
     context.register_mut().write_protectedMode_raw(0).unwrap();
@@ -129,9 +129,9 @@ pub fn parse_64bits(
 ) -> Option<(AddrType, String)> {
     let mut context = SpacesStruct::default();
     context.register_mut().write_longMode_raw(1).unwrap();
+    context.register_mut().write_bit64_raw(1).unwrap();
     context.register_mut().write_addrsize_raw(2).unwrap();
 
-    context.register_mut().write_bit64_raw(1).unwrap();
     context.register_mut().write_opsize_raw(1).unwrap();
     context.register_mut().write_segover_raw(0).unwrap();
     context.register_mut().write_protectedMode_raw(0).unwrap();


### PR DESCRIPTION
By writing `addrsize` (bit 4-5) with the value "2" then `bit64` (bit 4) with the value "1", the final value of `addrsize` becomes "3" that is invalid.

Is unclear if this is intentional and I implemented this wrong, or just a bug in ghidra.